### PR TITLE
switch to new rokubimini_ethercat_sdk

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ find_package(catkin REQUIRED)
 
 find_package(anydrive )
 find_package(elmo_ethercat_sdk )
-find_package(rokubi_rsl_ethercat_sdk )
+find_package(rokubimini_ethercat )
 
 if(anydrive_FOUND)
   add_definitions(-D_ANYDRIVE_FOUND_)
@@ -41,11 +41,11 @@ if(anydrive_FOUND)
     anydrive
   )
 endif()
-if(rokubi_rsl_ethercat_sdk_FOUND)
+if(rokubimini_ethercat_FOUND)
   add_definitions(-D_ROKUBI_FOUND_)
   set(PACKAGE_DEPENDENCIES
     ${PACKAGE_DEPENDENCIES}
-    rokubi_rsl_ethercat_sdk
+    rokubimini_ethercat
   )
 endif()
 if(elmo_ethercat_sdk_FOUND)
@@ -73,7 +73,7 @@ include_directories(
   include
   ${anydrive_INCLUDE_DIRS}
   ${elmo_ethercat_sdk_INCLUDE_DIRS}
-  ${rokubi_rsl_ethercat_sdk_INCLUDE_DIRS}
+  ${rokubimini_ethercat_INCLUDE_DIRS}
 )
 
 
@@ -90,7 +90,7 @@ target_link_libraries(
   ${PROJECT_NAME}
   ${anydrive_LIBRARIES}
   ${elmo_ethercat_sdk_LIBRARIES}
-  ${rokubi_rsl_ethercat_sdk_LIBRARIES}
+  ${rokubimini_ethercat_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
   stdc++fs
 )
@@ -105,7 +105,7 @@ add_dependencies(
   standalone
   ${PROJECT_NAME}
   ${anydrive_EXPORTED_TARGETS}
-  ${rokubi_rsl_ethercat_sdk_EXPORTED_TARGETS}
+  ${rokubimini_ethercat_EXPORTED_TARGETS}
   ${elmo_ethercat_sdk_EXPORTED_TARGETS}
 )
 target_link_libraries(
@@ -113,7 +113,7 @@ target_link_libraries(
   ${PROJECT_NAME}
   ${anydrive_LIBRARIES}
   ${elmo_ethercat_sdk_LIBRARIES}
-  ${rokubi_rsl_ethercat_sdk_LIBRARIES}
+  ${rokubimini_ethercat_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
   -pthread
   stdc++fs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Configures the EtherCAT communication with the following sdks:
 
 - anydrive_sdk
-- rokubi_rsl_ethercat_sdk
+- rokubimini_ethercat_sdk
 - elmo_ethercat_sdk 
 
 Any single SDK or any combination of SDKs may be used.
@@ -11,15 +11,11 @@ The build system automatically builds the EtherCAT device SDKs available in the 
 In the future this will be changed to a plugin architecture
 
 ## Building
-__You will need at least gcc version >= 8.4__.
-This requires the following for devices running Ubuntu 18.04:
-
-- install gcc-8 and g++-8: `sudo apt install gcc-8 g++-8`
-- configure catkin in your workspace: `catkin config --cmake-args -DCMAKE_CXX_COMPILER=/usr/bin/g++-8 -DOTHER_CMAKE_VARIABLES_YOU_WANT_TO_SET_EG_BUILD_TYPE`.
+Requires gcc ≥ 7.5 (default for Ubuntu ≥ 18.04).
 
 ### Dependencies
 - __optional__ anydrive_sdk (refactoring/ethercat_sdk_master)
-- __optional__ rokubi_rsl_ethercat_sdk (refactoring/ethercat_sdk_master)
+- __optional__ rokubimini_ethercat_sdk (refactoring/ethercat_sdk_master)
 - __optional__ elmo_ethercat_sdk (refactoring/ethercat_sdk_master)
 - ethercat_sdk_master (master)
 - soem_interface (release)

--- a/example_config/device_configurations/rokubi.yaml
+++ b/example_config/device_configurations/rokubi.yaml
@@ -1,70 +1,70 @@
-
+max_command_age:                   .inf
+auto_stage_last_command:           true
 set_reading_to_nan_on_disconnect:  false
 
-imu_acceleration_range:            1
-imu_angular_rate_range:            1
+imu_acceleration_range: 1
+imu_angular_rate_range: 1
 
-imu_acceleration_filter:           1
-imu_angular_rate_filter:           3
+imu_acceleration_filter: 1
+imu_angular_rate_filter: 3
 
 force_torque_filter:
-  sinc_filter_size:                512
-  chop_enable:                     false
-  fir_disable:                     true
-  fast_enable:                     false
+  sinc_filter_size: 512
+  chop_enable:      false
+  fir_disable:      true
+  fast_enable:      false
 
 force_torque_offset:
-  Fx:                              0.0
-  Fy:                              0.0
-  Fz:                              0.0
-  Tx:                              0.0
-  Ty:                              0.0
-  Tz:                              0.0
+  Fx: 0.0
+  Fy: 0.0
+  Fz: 0.0
+  Tx: 0.0
+  Ty: 0.0
+  Tz: 0.0
 
 sensor_configuration:
-  calibration_matrix_active:       true
-  temperature_compensation_active: true
-  imu_active:                      1   #0=no IMU, 1=internal, 2=external, 3=both
-  coordinate_system_active:        false
-  inertia_compensation_active:     0
-  orientation_estimation_active:   0
-
+  calibration_matrix_active:            true
+  temperature_compensation_active:      true
+  imu_active:                           1   #0=no IMU, 1=internal, 2=external, 3=both
+  coordinate_system_active:             false
+  inertia_compensation_active:          0
+  orientation_estimation_active:        0
+use_custom_calibration:                 false
 sensor_calibration:
-  use_custom_calibration:          false
   calibration_matrix:
-    1_1:                           -0.0120389
-    1_2:                           0.0206676
-    1_3:                           0.0011164
-    1_4:                           0.0010681
-    1_5:                           0.0006295
-    1_6:                           0.0002029
-    2_1:                           -0.0109678
-    2_2:                           -0.0207696
-    2_3:                           -0.0004745
-    2_4:                           -0.0010578
-    2_5:                           0.0005841
-    2_6:                           0.0001810
-    3_1:                           0.0217535
-    3_2:                           -0.0005980
-    3_3:                           -0.0002701
-    3_4:                           -0.0000395
-    3_5:                           -0.0011409
-    3_6:                           0.0001944
-    4_1:                           0.0155252
-    4_2:                           0.0100866
-    4_3:                           -0.0148265
-    4_4:                           0.0003659
-    4_5:                           -0.0005838
-    4_6:                           0.0000055
-    5_1:                           -0.0169726
-    5_2:                           0.0114251
-    5_3:                           -0.0146247
-    5_4:                           0.0004339
-    5_5:                           0.0006094
-    5_6:                           0.0000011
-    6_1:                           -0.0001013
-    6_2:                           -0.0197085
-    6_3:                           -0.0146952
-    6_4:                           -0.0007251
-    6_5:                           -0.0000145
-    6_6:                           -0.0000077
+    c11:  -0.0120389
+    c12:  0.0206676
+    c13:  0.0011164
+    c14:  0.0010681
+    c15:  0.0006295
+    c16:  0.0002029
+    c21:  -0.0109678
+    c22:  -0.0207696
+    c23:  -0.0004745
+    c24:  -0.0010578
+    c25:  0.0005841
+    c26:  0.0001810
+    c31:  0.0217535
+    c32:  -0.0005980
+    c33:  -0.0002701
+    c34:  -0.0000395
+    c35:  -0.0011409
+    c36:  0.0001944
+    c41:  0.0155252
+    c42:  0.0100866
+    c43:  -0.0148265
+    c44:  0.0003659
+    c45:  -0.0005838
+    c46:  0.0000055
+    c51:  -0.0169726
+    c52:  0.0114251
+    c53:  -0.0146247
+    c54:  0.0004339
+    c55:  0.0006094
+    c56:  0.0000011
+    c61:  -0.0001013
+    c62:  -0.0197085
+    c63:  -0.0146952
+    c64:  -0.0007251
+    c65:  -0.0000145
+    c66:  -0.0000077

--- a/example_config/setup.yaml
+++ b/example_config/setup.yaml
@@ -15,6 +15,7 @@ ethercat_devices:
      configuration_file:                device_configurations/rokubi.yaml
      ethercat_bus:                      enx00249b4f53e3
      ethercat_address:                  3
+     ethercat_pdo_type:                 Z
 
    - type:                              Elmo
      name:                              ElmoTwitter

--- a/jenkins-pipeline
+++ b/jenkins-pipeline
@@ -1,2 +1,2 @@
 library 'continuous_integration_pipeline'
-ciPipeline("--dependencies git@bitbucket.org:leggedrobotics/anydrive_sdk.git;refactoring/ethercat_sdk_master https://github.com/leggedrobotics/elmo_ethercat_sdk;refactoring/ethercat_sdk_master")
+ciPipeline("--dependencies git@bitbucket.org:leggedrobotics/anydrive_sdk.git;refactoring/ethercat_sdk_master https://github.com/leggedrobotics/elmo_ethercat_sdk;refactoring/ethercat_sdk_master git@bitbucket.org:leggedrobotics/rokubimini_ethercat_sdk.git;refactoring/ethercat_sdk_master")

--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
   <-->
   <depend>anydrive</depend>
   <depend>elmo_ethercat_sdk</depend>
-  <depend>rokubi_rsl_ethercat_sdk</depend>
+  <depend>rokubimini_ethercat</depend>
 
 </package>

--- a/src/EthercatDeviceConfigurator.cpp
+++ b/src/EthercatDeviceConfigurator.cpp
@@ -26,7 +26,7 @@
 
 /*Bota rokubi and SenseOne sensors*/
 #ifdef _ROKUBI_FOUND_
-#include "rokubi_rsl_ethercat_sdk/Rokubi.hpp"
+#include "rokubimini_ethercat/RokubiminiEthercat.hpp"
 #endif
 
 /*yaml-cpp*/
@@ -171,7 +171,7 @@ void EthercatDeviceConfigurator::parseFile(std::string path)
             }
             else
             {
-                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + "has no entry type");
+                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + " has no entry type");
             }
 
             //name - entry
@@ -182,7 +182,7 @@ void EthercatDeviceConfigurator::parseFile(std::string path)
             }
             else
             {
-                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + "has no entry name");
+                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + " has no entry name");
             }
 
             //configuration_file - entry
@@ -192,7 +192,7 @@ void EthercatDeviceConfigurator::parseFile(std::string path)
             }
             else
             {
-                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + "has no entry configuration_file");
+                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + " has no entry configuration_file");
             }
 
             //ethercat_bus_address - entry
@@ -202,7 +202,7 @@ void EthercatDeviceConfigurator::parseFile(std::string path)
             }
             else
             {
-                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + "has no entry ethercat_bus_address");
+                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + " has no entry ethercat_bus_address");
             }
 
             //ethercat_bus - entry
@@ -212,11 +212,11 @@ void EthercatDeviceConfigurator::parseFile(std::string path)
             }
             else
             {
-                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + "has no entry ethercat_bus");
+                throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + " has no entry ethercat_bus");
             }
 
             //ethercat_pdo_type - entry
-            if(entry.type == EthercatSlaveType::Anydrive)
+            if(entry.type == EthercatSlaveType::Anydrive || entry.type == EthercatSlaveType::Rokubi)
             {
                 if(child["ethercat_pdo_type"])
                 {
@@ -224,7 +224,7 @@ void EthercatDeviceConfigurator::parseFile(std::string path)
                 }
                 else
                 {
-                    throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + "has no entry ethercat_pdo_type");
+                    throw std::runtime_error("[EthercatDeviceConfigurator] Node: " + child.Tag() + " has no entry ethercat_pdo_type");
                 }
             }
 
@@ -300,11 +300,37 @@ void EthercatDeviceConfigurator::setup(bool startup)
         case EthercatSlaveType::Rokubi:
         {
 #ifdef _ROKUBI_FOUND_
+            rokubimini::ethercat::PdoTypeEnum pdo = rokubimini::ethercat::PdoTypeEnum::NA;
+            if(entry.ethercat_pdo_type == "A")
+            {
+                pdo = rokubimini::ethercat::PdoTypeEnum::A;
+            }
+            else if(entry.ethercat_pdo_type == "B")
+            {
+                pdo = rokubimini::ethercat::PdoTypeEnum::B;
+            }
+            else if(entry.ethercat_pdo_type == "C")
+            {
+                pdo = rokubimini::ethercat::PdoTypeEnum::C;
+            }
+            else if(entry.ethercat_pdo_type == "Z")
+            {
+                pdo = rokubimini::ethercat::PdoTypeEnum::Z;
+            }
+            else if(entry.ethercat_pdo_type == "EXTIMU")
+            {
+                pdo = rokubimini::ethercat::PdoTypeEnum::EXTIMU;
+            }
+            else
+            {
+                throw std::runtime_error("[EthercatDeviceConfigurator] PDO unknown: " + entry.ethercat_pdo_type);
+            }
+
             //Handle configuration file path
             std::string configuration_file_path = handleFilePath(entry.config_file_path,m_setup_file_path);
-            slave = rokubi::Rokubi::deviceFromFile(configuration_file_path, entry.name, entry.ethercat_address);
+            slave = rokubimini::ethercat::RokubiminiEthercat::deviceFromFile(configuration_file_path, entry.name, entry.ethercat_address, pdo);
 #else
-            throw std::runtime_error("rokubi_ethercat_sdk not available");
+            throw std::runtime_error("rokubimini_ethercat_sdk not available");
 #endif
         }
             break;

--- a/src/standalone.cpp
+++ b/src/standalone.cpp
@@ -43,7 +43,7 @@
 #include <elmo_ethercat_sdk/Elmo.hpp>
 #endif
 #ifdef _ROKUBI_FOUND_
-#include <rokubi_rsl_ethercat_sdk/Rokubi.hpp>
+#include <rokubimini_ethercat/RokubiminiEthercat.hpp>
 #endif
 #include <thread>
 #include <csignal>
@@ -114,7 +114,7 @@ void worker()
             else if(configurator->getInfoForSlave(slave).type == EthercatDeviceConfigurator::EthercatSlaveType::Rokubi)
             {
 #ifdef _ROKUBI_FOUND_
-                std::shared_ptr<rokubi::Rokubi> rokubi_slave_ptr = std::dynamic_pointer_cast<rokubi::Rokubi>(slave);
+                std::shared_ptr<rokubimini::ethercat::RokubiminiEthercat> rokubi_slave_ptr = std::dynamic_pointer_cast<rokubimini::ethercat::RokubiminiEthercat>(slave);
                 // Do things with the Rokubi sensors here
 #endif
             }
@@ -201,7 +201,7 @@ void anydriveReadingCb(const std::string& name, const anydrive::ReadingExtended&
 }
 #endif
 #ifdef _ROKUBI_FOUND_
-void rokubiReadingCb(const std::string& name, const rokubi::Reading& reading)
+void rokubiReadingCb(const std::string& name, const rokubimini::Reading& reading)
 {
     // std::cout << "Reading of rokubi '" << name << "'\n"
     //           << "Force X: " << reading.getForceX() << "\n\n";
@@ -240,7 +240,7 @@ int main(int argc, char**argv)
     }
 #endif
 #if _ROKUBI_FOUND_
-    for(const auto& device : configurator->getSlavesOfType<rokubi::Rokubi>()){
+    for(const auto& device : configurator->getSlavesOfType<rokubimini::ethercat::RokubiminiEthercat>()){
         device->addReadingCb(rokubiReadingCb);
     }
 #endif


### PR DESCRIPTION
# Switch to standard Rokubi SDK
This changes the supported SDK for the Rokubi sensors from the deprecated *rokubi_rsl_ethercat_sdk* to the standard *rokubimini_ethercat_sdk*, patched for the *ethercat_sdk_master* (i.e. the *refactoring/ethercat_sdk_master* branch).

The standalone executable, the config files and the readme have been changed accordingly.