### PR TITLE
Remove anydrive_dependency from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -33,7 +33,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
       Optional dependencies.
       Any single drive sdk or any combination of sdks may be used.
   <-->
-  <depend>anydrive</depend>
   <depend>elmo_ethercat_sdk</depend>
   <depend>maxon_epos_ethercat_sdk</depend>
   <depend>rokubimini_ethercat</depend>


### PR DESCRIPTION
Remove the anydrive dependency from the package.xml to prevent depending packages to pull this into their builds. If we want to have CI build the anydrive specific code, I would propose to pull the package in via the jenkins-pipeline