### PR TITLE
Rename/rokubi

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@ find_package(catkin REQUIRED)
 find_package(anydrive )
 find_package(elmo_ethercat_sdk )
 find_package(maxon_epos_ethercat_sdk )
-find_package(rokubimini_ethercat )
+find_package(rokubimini_rsl_ethercat )
 
 if(anydrive_FOUND)
   add_definitions(-D_ANYDRIVE_FOUND_)
@@ -42,11 +42,11 @@ if(anydrive_FOUND)
     anydrive
   )
 endif()
-if(rokubimini_ethercat_FOUND)
+if(rokubimini_rsl_ethercat_FOUND)
   add_definitions(-D_ROKUBI_FOUND_)
   set(PACKAGE_DEPENDENCIES
     ${PACKAGE_DEPENDENCIES}
-    rokubimini_ethercat
+    rokubimini_rsl_ethercat
   )
 endif()
 if(elmo_ethercat_sdk_FOUND)
@@ -83,7 +83,7 @@ include_directories(
   ${anydrive_INCLUDE_DIRS}
   ${elmo_ethercat_sdk_INCLUDE_DIRS}
   ${maxon_epos_ethercat_sdk_INCLUDE_DIRS}
-  ${rokubimini_ethercat_INCLUDE_DIRS}
+  ${rokubimini_rsl_ethercat_INCLUDE_DIRS}
 )
 
 
@@ -101,7 +101,7 @@ target_link_libraries(
   ${anydrive_LIBRARIES}
   ${elmo_ethercat_sdk_LIBRARIES}
   ${maxon_epos_ethercat_sdk_LIBRARIES}
-  ${rokubimini_ethercat_LIBRARIES}
+  ${rokubimini_rsl_ethercat_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
   stdc++fs
 )
@@ -116,7 +116,7 @@ add_dependencies(
   standalone
   ${PROJECT_NAME}
   ${anydrive_EXPORTED_TARGETS}
-  ${rokubimini_ethercat_EXPORTED_TARGETS}
+  ${rokubimini_rsl_ethercat_EXPORTED_TARGETS}
   ${elmo_ethercat_sdk_EXPORTED_TARGETS}
   ${maxon_epos_ethercat_sdk_EXPORTED_TARGETS}
 )
@@ -126,7 +126,7 @@ target_link_libraries(
   ${anydrive_LIBRARIES}
   ${elmo_ethercat_sdk_LIBRARIES}
   ${maxon_epos_ethercat_sdk_LIBRARIES}
-  ${rokubimini_ethercat_LIBRARIES}
+  ${rokubimini_rsl_ethercat_LIBRARIES}
   ${YAML_CPP_LIBRARIES}
   -pthread
   stdc++fs

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ In the future this will be changed to a plugin architecture
 Requires gcc ≥ 7.5 (default for Ubuntu ≥ 18.04).
 
 ### Dependencies
-- __optional__ anydrive_sdk (refactoring/ethercat_sdk_master)
-- __optional__ rokubimini_ethercat_sdk (refactoring/ethercat_sdk_master)
+- __optional__ anydrive_sdk (master)
+- __optional__ rokubimini_ethercat_sdk (master)
 - __optional__ elmo_ethercat_sdk (master)
 - __optional__ maxon_epos_ethercat_sdk (master)
 - ethercat_sdk_master (master)

--- a/jenkins-pipeline
+++ b/jenkins-pipeline
@@ -1,2 +1,2 @@
 library 'continuous_integration_pipeline'
-ciPipeline("--dependencies git@bitbucket.org:leggedrobotics/rokubimini_ethercat_sdk.git;master")
+ciPipeline("")

--- a/package.xml
+++ b/package.xml
@@ -36,6 +36,6 @@ THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND 
   <depend>anydrive</depend>
   <depend>elmo_ethercat_sdk</depend>
   <depend>maxon_epos_ethercat_sdk</depend>
-  <depend>rokubimini_ethercat</depend>
+  <depend>rokubimini_rsl_ethercat</depend>
 
 </package>

--- a/src/EthercatDeviceConfigurator.cpp
+++ b/src/EthercatDeviceConfigurator.cpp
@@ -31,7 +31,7 @@
 
 /*Bota rokubi and SenseOne sensors*/
 #ifdef _ROKUBI_FOUND_
-#include "rokubimini_ethercat/RokubiminiEthercat.hpp"
+#include "rokubimini_rsl_ethercat/RokubiminiEthercat.hpp"
 #endif
 
 /*yaml-cpp*/

--- a/src/standalone.cpp
+++ b/src/standalone.cpp
@@ -46,7 +46,7 @@
 #include <maxon_epos_ethercat_sdk/Maxon.hpp>
 #endif
 #ifdef _ROKUBI_FOUND_
-#include <rokubimini_ethercat/RokubiminiEthercat.hpp>
+#include <rokubimini_rsl_ethercat/RokubiminiEthercat.hpp>
 #endif
 #include <thread>
 #include <csignal>


### PR DESCRIPTION
# Renaming the Rokubi SDK
This adapts the changes from [this PR in the rokubimini_ethercat_sdk (RSL version)](https://bitbucket.org/leggedrobotics/rokubimini_ethercat_sdk/pull-requests/37/rename-rsl)

This shall not be merged before the aforementioned PR has been merged.

## Dependencies
To try this out: use the *rename/rsl* branch of the rokubimini_ethercat_sdk.

When we merge this PR the Rokubi changes will however be on master.